### PR TITLE
Pass on command line arguments to Testcafe

### DIFF
--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const args = require('minimist')(process.argv.slice(2));
 const createTestCafe = require('testcafe');
 const testControllerHolder = require('../support/testControllerHolder');
 const {AfterAll, setDefaultTimeout, Before, After, Status} = require('cucumber');
@@ -33,7 +34,7 @@ function runTest(iteration, browser) {
                 .src('./test.js')
                 .screenshots('reports/screenshots/', true)
                 .browsers(browser)
-                .run()
+                .run(args)
                 .catch(function(error) {
                     console.log(error);
                 });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "base64-img": "^1.0.4",
     "cucumber": "^4.2.1",
     "eslint": "^4.19.1",
+    "minimist": "^1.2.0",
     "testcafe": "^0.19.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow testcafe command line parameters to be used, e.g. --speed=0.1