### PR TITLE
fix adding screenshot to report on failure

### DIFF
--- a/features/support/errorHandling.js
+++ b/features/support/errorHandling.js
@@ -13,8 +13,7 @@ exports.addErrorToController = function() {
 };
 
 exports.ifErrorTakeScreenshot = function(resolvedTestController) {
-
-    if (hooks.getIsTestCafeError() === true && testController.testRun.opts.takeScreenshotsOnFails === true) {
+    if (hooks.getIsTestCafeError() === true && testController.testRun.opts.screenshots.takeOnFails === true) {
         if (process.argv.includes('--format') || process.argv.includes('-f') || process.argv.includes('--format-options')) {
             resolvedTestController.executionChain._state = "fulfilled"
             return resolvedTestController.takeScreenshot().then(function(path) {

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -28,7 +28,10 @@ function runTest(iteration, browser) {
             const runner = tc.createRunner();
             return runner
                 .src('./test.js')
-                .screenshots('reports/screenshots/', true)
+                .screenshots({
+                    path : 'reports/screenshots/',
+                    takeOnFails : true
+                    })
                 .browsers(browser)
                 .run()
                 .catch(function(error) {


### PR DESCRIPTION
Fix adding screenshot on failure to report.
Obsolete screenshot option was used in runner. 